### PR TITLE
Gracefully handle missing Opus minor version

### DIFF
--- a/flac2all_pkg/opus.py
+++ b/flac2all_pkg/opus.py
@@ -21,6 +21,7 @@ class opus:
     def __init__(self, opusencopts):
         # Work out what version of opus we have
         self.version = None  # Undefined by default
+        self.opts = opusencopts
 
         # Opus is really all over the place, each version has different
         # switches. I guess that is what happens with new stuff
@@ -33,13 +34,17 @@ class opus:
                 os.path.join(ipath.opusencpath, "opusenc"), "-v"
             ]).decode("utf-8")
 
-        # Opus has stabalised, on versioning, and most distros have the stable
-        # version, so we got rid of the logic that deals wit opeus version testing.
+        # Opus has stabilised on versioning, and most distros have the stable
+        # version, so we got rid of the logic that deals with opus version testing.
 
-        data = re.search("\d+\.\d+\.\d+", data).group(0)
+        match = re.search("\d+\.\d+\.\d+?", data)
+        if match:
+            data = match.group(0)
+        else:
+            return
+
         (release, major, minor) = map(lambda x: int(x), data.split('.'))
         self.version = (release, major, minor)
-        self.opts = opusencopts
 
     def convert(self, infile, outfile):
         # As the new versions of opus support flac natively, I think that the


### PR DESCRIPTION
Back again :wave:  `opusenc` really likes to break the version check regex. This is what my version info looks like:

```
opusenc opus-tools 0.2 (using libopus 1.4)
Copyright (C) 2008-2018 Xiph.Org Foundation
```

...so no minor version meant an `AttributeError` for the `.group(0)` call. This change accounts for a missing regex match by gating the remainder of the `self.version` assignment behind a check for a valid regex match.