### PR TITLE
Account for when libopus version has no minor version num

### DIFF
--- a/flac2all_pkg/opus.py
+++ b/flac2all_pkg/opus.py
@@ -35,10 +35,20 @@ class opus:
 
         # Opus has stabalised, on versioning, and most distros have the stable
         # version, so we got rid of the logic that deals wit opeus version testing.
+        match = re.search(r"libopus (\d+)\.(\d+)(?:\.(\d+))?", data)
+        if match is None:
+            match = re.search(r"\d+\.\d+\.\d+", data)
+            if match is None:
+                self.version = None
+            else:
+                self.version = tuple(map(int, match.group(0).split(".")))
+        else:
+            self.version = (
+                int(match.group(1)),
+                int(match.group(2)),
+                int(match.group(3) or 0),
+            )
 
-        data = re.search("\d+\.\d+\.\d+", data).group(0)
-        (release, major, minor) = map(lambda x: int(x), data.split('.'))
-        self.version = (release, major, minor)
         self.opts = opusencopts
 
     def convert(self, infile, outfile):


### PR DESCRIPTION
opus 1.4 doesn't give a minor version num in the `opusenc -V` output:

```
opusenc opus-tools 0.2 (using libopus 1.4)
Copyright (C) 2008-2018 Xiph.Org Foundation
```

Added regex to account for both cases. Needed to add `libopus` at the front of the regex to distinguish between the `libopus` version and the `opus-tools` version, so for backwards compatibility I kept the old code in case there is no match (not sure if older versions have the `libopus` in front of the version number as well).

Closes #62.