### PR TITLE
Move ready command to top of worker thread loop

### DIFF
--- a/flac2all_pkg/core.py
+++ b/flac2all_pkg/core.py
@@ -347,8 +347,8 @@ class encode_worker(transcoder):
         # send tasks
 
         # Process tasks until EOL received
-        self.send_json(["READY"])
         while True:
+            self.send_json(["READY"])
             try:
                 message = self.tsock.recv_json(flags=zmq.NOBLOCK)
                 infile, mode, opts = message
@@ -399,5 +399,3 @@ class encode_worker(transcoder):
                 raise(e)
             # We send the result back up the chain
             self.send_json(result)
-            # If we reach this point, means nothing messed up, and we can send READY command
-            self.send_json(["READY"])


### PR DESCRIPTION
Worker thread can get stuck in a timeout -> continue loop and needs to send the ready command again in this case to start receiving commands again.