### PR TITLE
Set multiprocessing start method

### DIFF
--- a/flac2all_pkg/__init__.py
+++ b/flac2all_pkg/__init__.py
@@ -140,6 +140,7 @@ def clustered_encode(localworkers=False):
             from flac2all_worker import main as worker
         except ImportError:
             from .flac2all_worker import main as worker
+        mp.set_start_method("fork")
         local_worker = mp.Process(target=worker, args=("localhost",))
         local_worker.start()
 


### PR DESCRIPTION
In Python 3.14, the default start method on Linux systems changed from `fork` to `forkserver`.
The `forkserver` start method is incompatible with the logic that waits for all child processes to die (the server process lingers).

Therefore, we explicitly set the start method to `fork`, which does not face the same issue.

Relevant documentation:

https://docs.python.org/3/library/multiprocessing.html#multiprocessing-start-methods

Closes #72.